### PR TITLE
Fix Supported Clients For OracleDB

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -12,7 +12,7 @@ const defaultKnexConfig = {
   }
 }
 
-const supportedClients = ['pg', 'sqlite3', 'better-sqlite3', 'mysql', 'mysql2', 'oracle', 'mssql']
+const supportedClients = ['pg', 'sqlite3', 'better-sqlite3', 'mysql', 'mysql2', 'oracledb', 'mssql']
 
 function fastifyObjectionjs (fastify, options, next) {
   const knexConfig = Object.assign(


### PR DESCRIPTION
https://github.com/knex/knex/blame/master/lib/constants.js does not use ```oracle``` but ```oracledb```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jarcodallo/fastify-objectionjs/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Plugin throws an error if using ```oracledb``` for client in the knex connection string because it expects ```oracle```.
If we change to ```oracle```, Knex will refuse because it does not know ```oracle``` for the client name.

Issue Number: N/A

## What is the new behavior?
Plugin will work for oracledb

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
